### PR TITLE
Reroute /sprite into /api/v1/sprite

### DIFF
--- a/backend/sprites/main.py
+++ b/backend/sprites/main.py
@@ -32,7 +32,7 @@ app.add_middleware(
 )
 
 
-@app.get("/sprite")
+@app.get("/api/v1/sprite")
 def make_sprite(
     q: str = None,
     n_iters: int = 1,

--- a/backend/tests/test_app.py
+++ b/backend/tests/test_app.py
@@ -8,6 +8,6 @@ client = TestClient(app)
 
 
 def test_make_sprite_default_values():
-    response = client.get("/sprite")
+    response = client.get("/api/v1/sprite")
     assert response.status_code == 200
     assert response.headers["content-type"] == "image/png"

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -25,7 +25,7 @@ export default {
     return {
       img: "",
       requesturl: "",
-      baseurl: "http://localhost:8000/sprite",
+      baseurl: "http://localhost:8000/api/v1/sprite",
       spriteConfig: {
         q: null,
         extRate: 0.125,


### PR DESCRIPTION
Resolves #27
Reference #6

It's good to standardize the route under /api, then we just add versions
as we go. I won't be closing #6 because the main goal there is to create
a better "templating" system for the backend.

Signed-off-by: Lester James V. Miranda <ljvmiranda@gmail.com>